### PR TITLE
fix(YagrCore): fix resize handling

### DIFF
--- a/src/Yagr.scss
+++ b/src/Yagr.scss
@@ -37,6 +37,8 @@
     height: 100%;
     font-family: var(--yagr-font-family);
     background-color: var(--yagr-background);
+    // To have properly resize logic in case of using `chart.size.adaptive` property
+    overflow: hidden;
 
     .uplot {
         width: 100%;


### PR DESCRIPTION
Yagr may have bug with resize handling in case of using 100% space of page. For example - in case of using `Yagr` in iframe

<details>
<summary>Bug example:</summary>

![resize_bug](https://github.com/gravity-ui/yagr/assets/26501073/7f07dd02-2b00-400f-bad0-c2ffcfd7f864)
</details>