### PR TITLE
fix: set option "updateLegend" to false in "extended" behaviour

### DIFF
--- a/src/YagrCore/plugins/legend/legend.ts
+++ b/src/YagrCore/plugins/legend/legend.ts
@@ -174,7 +174,7 @@ export default class LegendPlugin {
         const onSerieClickExtended = (serieNode: HTMLElement) => {
             const changeVisibility = (id: string, visibility: boolean) => {
                 const node = yagr.root.querySelector(`[data-serie-id="${id}"]`);
-                yagr.setVisible(id, visibility, true);
+                yagr.setVisible(id, visibility, false);
                 node?.classList[visibility ? 'remove' : 'add']('yagr-legend__item_hidden');
             };
 


### PR DESCRIPTION
While testing a new feature on another project, I found really poor performance when the number of items in the legend exceeded ~50. 

When I set this option to ```false``` for the first time, the legend updated with a delay of one step. Now it works fine, and I think the problem was due to the first implementation.