### PR TITLE
fix: width and height of plotlines

### DIFF
--- a/src/YagrCore/plugins/plotLines/plotLines.ts
+++ b/src/YagrCore/plugins/plotLines/plotLines.ts
@@ -3,7 +3,7 @@ import UPlot from 'uplot';
 import {DEFAULT_X_SCALE, DEFAULT_CANVAS_PIXEL_RATIO} from '../../defaults';
 import {PLineConfig, PlotLineConfig, YagrPlugin} from '../../types';
 import {DrawOrderKey} from '../../utils/types';
-import {asPlain, deepIsEqual} from '../../utils/common';
+import {deepIsEqual} from '../../utils/common';
 
 const MAX_X_SCALE_LINE_OFFSET = 0;
 const DRAW_MAP = {
@@ -111,7 +111,6 @@ export default function plotLinesPlugin(yagr: Yagr, plotLinesCfg: PlotLineConfig
                 const pConf = plotLineConfig as PLineConfig;
 
                 ctx.beginPath();
-                const axisSize = asPlain(u.axes.find((a) => a.scale === scale)?.size);
 
                 if (scale === DEFAULT_X_SCALE) {
                     /** Workaround to ensure that plot line will not be drawn over axes */
@@ -123,10 +122,10 @@ export default function plotLinesPlugin(yagr: Yagr, plotLinesCfg: PlotLineConfig
 
                     ctx.moveTo(from, top);
 
-                    ctx.lineTo(from, height + (axisSize ?? 0));
+                    ctx.lineTo(from, height + top);
                 } else {
                     ctx.moveTo(left, from);
-                    ctx.lineTo(width, from);
+                    ctx.lineTo(width + left, from);
                 }
 
                 ctx.lineWidth = pConf.width || DEFAULT_CANVAS_PIXEL_RATIO;


### PR DESCRIPTION
Before fix:

<img width="831" alt="image" src="https://github.com/gravity-ui/yagr/assets/62965405/e0490b7e-6aa1-44f2-b204-2b14c36052a4">
<img width="182" alt="image" src="https://github.com/gravity-ui/yagr/assets/62965405/8153e7d8-3aba-4798-a8d7-3dbb30fda999">

After fix:

<img width="815" alt="image" src="https://github.com/gravity-ui/yagr/assets/62965405/767f5f57-ec5e-44b9-a4df-ec52eac68aa1">
<img width="149" alt="image" src="https://github.com/gravity-ui/yagr/assets/62965405/71460386-5a24-44e8-9a5e-11e1eeb7b624">

