### PR TITLE
Use max markers options

### DIFF
--- a/src/YagrCore/plugins/cursor/cursor.ts
+++ b/src/YagrCore/plugins/cursor/cursor.ts
@@ -206,8 +206,10 @@ export default function CursorPlugin(
 
                 const emptyLines = uplotOptions.series.filter((s) => s.empty).length;
                 const totalLines = uplotOptions.series.length - 1;
+                const maxCursors = opts?.maxMarkers ?? MAX_CURSORS;
+
                 uplotOptions.cursor.points = {
-                    show: totalLines - emptyLines <= MAX_CURSORS ? cursorPoint : false,
+                    show: totalLines - emptyLines <= maxCursors ? cursorPoint : false,
                     size: (u: uPlot, seriesIdx: number) => {
                         const serie = u.series[seriesIdx];
                         return (

--- a/tests/plugins/cursor.test.ts
+++ b/tests/plugins/cursor.test.ts
@@ -41,6 +41,30 @@ describe('cursor plugin', () => {
         });
     });
 
+    describe('markers', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+
+        afterAll(() => {
+            document.body.removeChild(el);
+        });
+
+        new Yagr(el, {
+            timeline: [1, 2, 3],
+            cursor: {maxMarkers: 100 },
+            series: Array.from({ length: 100 }).fill(0).map((_, i) => ({
+                id: String(i),
+                data: [1, 2, 3],
+                color: 'rgb(255, 0, 0)'
+            }))
+        });
+
+        it('should use the maxMarkers option', () => {
+            const n = document.querySelectorAll('.yagr-point');
+            expect(n.length).toBe(100 + 2);
+        });
+    });
+
     describe('methods', () => {
         const el = document.createElement('div');
         document.body.appendChild(el);

--- a/tests/plugins/cursor.test.ts
+++ b/tests/plugins/cursor.test.ts
@@ -49,7 +49,7 @@ describe('cursor plugin', () => {
             document.body.removeChild(el);
         });
 
-        new Yagr(el, {
+        const y = new Yagr(el, {
             timeline: [1, 2, 3],
             cursor: {maxMarkers: 100 },
             series: Array.from({ length: 100 }).fill(0).map((_, i) => ({
@@ -58,6 +58,8 @@ describe('cursor plugin', () => {
                 color: 'rgb(255, 0, 0)'
             }))
         });
+
+        y.reflow();
 
         it('should use the maxMarkers option', () => {
             const n = document.querySelectorAll('.yagr-point');


### PR DESCRIPTION
Hey, I noticed that the `maxMarkers` options is defined but never used.