### PR TITLE
fix: tooltip memory leak

### DIFF
--- a/src/YagrCore/plugins/tooltip/tooltip.ts
+++ b/src/YagrCore/plugins/tooltip/tooltip.ts
@@ -742,6 +742,9 @@ function YagrTooltipPlugin(yagr: Yagr, options: Partial<TooltipOptions> = {}): R
 
     const getUplotPlugin = () => ({
         hooks: {
+            destroy: () => {
+                tooltip.dispose();
+            },
             init: (u: uPlot) => {
                 tooltip.initWithUplot(u);
             },
@@ -763,6 +766,7 @@ function YagrTooltipPlugin(yagr: Yagr, options: Partial<TooltipOptions> = {}): R
         tooltip.reset();
 
         u.hooks.init!.push(uPlugin.hooks.init);
+        u.hooks.destroy!.push(uPlugin.hooks.destroy);
         u.hooks.setSize!.push(uPlugin.hooks.setSize);
         u.hooks.setCursor!.push(uPlugin.hooks.setCursor);
     }


### PR DESCRIPTION
uPlot has destroy hook, but here we never used is to unsubscribe from DOM events