### PR TITLE
fix(main): update uplot to v1.6.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.3.3",
       "license": "MIT",
       "dependencies": {
-        "uplot": "1.6.27"
+        "uplot": "1.6.31"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.22.5",
@@ -15117,9 +15117,9 @@
       }
     },
     "node_modules/uplot": {
-      "version": "1.6.27",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.27.tgz",
-      "integrity": "sha512-78U4ss5YeU65kQkOC/QAKiyII+4uo+TYUJJKvuxRzeSpk/s5sjpY1TL0agkmhHBBShpvLtmbHIEiM7+C5lBULg=="
+      "version": "1.6.31",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
+      "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -27430,9 +27430,9 @@
       }
     },
     "uplot": {
-      "version": "1.6.27",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.27.tgz",
-      "integrity": "sha512-78U4ss5YeU65kQkOC/QAKiyII+4uo+TYUJJKvuxRzeSpk/s5sjpY1TL0agkmhHBBShpvLtmbHIEiM7+C5lBULg=="
+      "version": "1.6.31",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
+      "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "uplot": "1.6.27"
+    "uplot": "1.6.31"
   }
 }

--- a/src/YagrCore/utils/types.ts
+++ b/src/YagrCore/utils/types.ts
@@ -15,6 +15,7 @@ export const Scale: YScale = {
         Ordinal: 2 as uScale.Distr.Ordinal,
         Logarithmic: 3 as uScale.Distr.Logarithmic,
         ArcSinh: 4 as uScale.Distr.ArcSinh,
+        Custom: 5 as uScale.Distr.Custom,
     },
 };
 


### PR DESCRIPTION
Versions of the package uplot before 1.6.31 are vulnerable to Prototype Pollution via the uplot.assign function due to missing check if the attribute resolves to the object prototype.

https://osv.dev/vulnerability/GHSA-34q8-jcq6-mc37