### PR TITLE
fix: baseline align for legend items

### DIFF
--- a/src/YagrCore/plugins/legend/legend.scss
+++ b/src/YagrCore/plugins/legend/legend.scss
@@ -19,6 +19,7 @@ $block: yagr-legend;
     &__items {
         display: flex;
         flex-flow: row wrap;
+        align-items: baseline;
         padding-left: 16px;
     }
 


### PR DESCRIPTION
Fix legend items align.

Before - "Hide all" is slightly higher than legend items texts:
<img width="862" alt="Screenshot 2025-01-27 at 16 49 13" src="https://github.com/user-attachments/assets/b9c6a639-5fc7-4c27-9082-c508d51f1119" />


After - "Hide all" and items texts are on the same line:
<img width="862" alt="Screenshot 2025-01-27 at 16 49 20" src="https://github.com/user-attachments/assets/acb0b45c-cd84-4c37-934e-a038a70a3d8b" />

Examples are from ydb-embedded-ui
