### PR TITLE
Updated uplot to 1.6.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.6.1",
       "license": "MIT",
       "dependencies": {
-        "uplot": "1.6.31"
+        "uplot": "^1.6.32"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.22.5",
@@ -15140,9 +15140,10 @@
       }
     },
     "node_modules/uplot": {
-      "version": "1.6.31",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
-      "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -27459,9 +27460,9 @@
       }
     },
     "uplot": {
-      "version": "1.6.31",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
-      "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,6 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
-    "uplot": "1.6.31"
+    "uplot": "^1.6.32"
   }
 }

--- a/src/YagrCore/defaults.ts
+++ b/src/YagrCore/defaults.ts
@@ -46,7 +46,15 @@ export const Y_AXIS_SIZE = (self: uPlot, values: string[], axisIdx: number) => {
         labelSize = axis.labelSize || DEFAULT_AXIS_FONT_SIZE;
 
         ctx.font = axis.labelFont ? axis.labelFont[0] : AXIS_LABEL_FONT;
-        const {fontBoundingBoxAscent: size} = ctx.measureText(axis.label);
+
+        let labelText: string;
+        if (typeof axis.label === 'function') {
+            labelText = axis.label(self, axisIdx, 0, 0);
+        } else {
+            labelText = axis.label;
+        }
+
+        const {fontBoundingBoxAscent: size} = ctx.measureText(labelText);
         labelSize = size;
         ctx.restore();
     }


### PR DESCRIPTION
This version also brought us a new ability for axis.label - it can be a function, I have done a workaround, but not a deep one, because we have not implemented label as a cb, as I see we use it as a string. 